### PR TITLE
Fix typo in doc title line

### DIFF
--- a/doc/projectile.txt
+++ b/doc/projectile.txt
@@ -1,4 +1,4 @@
-*projectile.txt* *projectile* Project configration
+*projectile.txt* *projectile* Project configuration
 
 Author:  Tim Pope <http://tpo.pe/>
 Repo:    https://github.com/tpope/vim-projectile


### PR DESCRIPTION
Change 'configration' to 'configuration.'
