### PR TITLE
Commands Aren't Available Until File Edited?

### DIFF
--- a/plugin/projectile.vim
+++ b/plugin/projectile.vim
@@ -65,6 +65,7 @@ augroup projectile
         \ if empty(&filetype) |
         \   call ProjectileDetect(expand('<afile>:p')) |
         \ endif
+  autocmd VimEnter * if expand("<amatch>") == "" | call ProjectileDetect(getcwd()) | endif
   autocmd BufWritePost .projections.json call ProjectileDetect(expand('<afile>:p'))
   autocmd BufNewFile *
         \ if !empty(b:projectiles) |


### PR DESCRIPTION
Say I have a project with the following `.projections.json` file:

``` json
{
  "lib/assembler/*": { "command": "lib" },
  "lib/assembler.rb": { "command": "lib" }
}
```

If I go into the root, there, and just type `vim`, the `:Elib` command doesn't auto-complete when I hit tab and running it give me `E492: Not an editor command: Elib`. If I open a file in the project, it works (whether by `vim assembler.gemspec` or `vim` and then the `:e` command).

Am I messing something up? Is this a known bug? Could it be fixed so that I don't have to open a file to get my fast navigation commands?
