### PR TITLE
Update to docs for **

### DIFF
--- a/doc/projectionist.txt
+++ b/doc/projectionist.txt
@@ -48,7 +48,8 @@ close          literal }
 
 From a globbing perspective, "*" is actually a stand in for "**/*".  For
 advanced cases, you can include both globs explicitly: "test/**/test_*.rb".
-When expanding with {}, the inner portion is collapsed to a single slash.
+In this case "**" and "*" are combined together. They can be pulled back apart
+with {dirname} and {basename} if needed.
 
 The full list of available properties in a projection is as follows:
 


### PR DESCRIPTION
Hi,
here's the slight docs modification for **.

I badly needed this feature for [this](https://github.com/capistrano/sshkit) project. I combed the `vim-projectionist` docs, but I still wasn't sure how `"test/**/test_*.rb"` works.
Due to wording of current docs: `...the inner portion is collapsed to a single slash...` I though that with `test/foo/test_baz.rb` I would get `"/baz".

I did the homework and read some previous issues before submitting a new one. [This](https://github.com/tpope/vim-projectionist/issues/14#issuecomment-41750115) comment nailed it.

Also, would you be open to expanding this change to include an example? `**` is kind of an advanced feature so it might deserve it.
