### PR TITLE
Added prompt if alternate file does not exist, asking if you want to create it

### DIFF
--- a/autoload/projectionist.vim
+++ b/autoload/projectionist.vim
@@ -480,7 +480,12 @@ function! s:edit_command(cmd, count, ...) abort
     endif
     let file = get(filter(copy(alternates), '!empty(getftype(v:val))'), 0, '')
     if empty(file)
-      return 'echoerr "No alternate file"'
+      let choice = confirm("No alternate file. Create?", "&Yes\n&No", 2, "Question")
+      if choice == 1
+        return a:cmd . ' ' . fnameescape(alternates[0])
+      else
+        return 'echoerr "No alternate file"'
+      endif
     endif
   endif
   if !isdirectory(fnamemodify(file, ':h'))


### PR DESCRIPTION
This does not have to be the final acceptable solution for #5 but this is what I plan to use until something is figured out. Instead of blindly creating a file, and instead of saying absolutely not I'm leaving it in the users hands to decide whether or not to create the missing alternate file. I'm open to suggestions here!
