### PR TITLE
Warn and exit if required after rails.vim

### DIFF
--- a/plugin/projectionist.vim
+++ b/plugin/projectionist.vim
@@ -1,6 +1,11 @@
 " Location:     plugin/projectionist.vim
 " Author:       Tim Pope <http://tpo.pe/>
 
+if exists('g:loaded_rails')
+  echoerr "projectionist.vim was loaded after rails.vim - expect errors!"
+  finish
+endif
+
 if exists("g:loaded_projectionist") || v:version < 700 || &cp
   finish
 endif


### PR DESCRIPTION
This situation is problematic because it breaks command in rails.vim such as the
alternate file (`:A`) command. When projectionist.vim is now required after
rails.vim, an error message appears and projectionist will not be loaded.

Also see https://github.com/tpope/vim-rails/issues/330
