### PR TITLE
Expose a method to list commands and scoped files

### DIFF
--- a/autoload/projectionist.vim
+++ b/autoload/projectionist.vim
@@ -452,6 +452,22 @@ function! projectionist#navigation_commands() abort
   return commands
 endfunction
 
+function! projectionist#list_all() abort
+    let categories = {}
+    for [category, globbed_files] in items(projectionist#navigation_commands())
+        let results = []
+        for format in map(globbed_files, 'v:val[1]')
+            if format !~# '\*'
+                continue
+            endif
+            let glob = substitute(format, '[^\/]*\ze\*\*[\/]\*', '', 'g')
+            let results += map(split(glob(glob), "\n"), '[s:match(v:val, format), v:val]')
+        endfor
+        let categories[category] = results
+    endfor
+    return categories
+endfunction
+
 function! s:open_projection(cmd, variants, ...) abort
   let formats = []
   for variant in a:variants


### PR DESCRIPTION
Expose projectionist#list_all(), an extended version of projectionist#navigation_commands. As mentioned in #32.
