### PR TITLE
Use `exists` instead of `silent` with `ProjectionistActivate` autocmd

### DIFF
--- a/autoload/projectionist.vim
+++ b/autoload/projectionist.vim
@@ -387,7 +387,9 @@ function! projectionist#activate() abort
     break
   endfor
 
-  silent doautocmd User ProjectionistActivate
+  if exists('#User#ProjectionistActivate')
+    doautocmd User ProjectionistActivate
+  endif
 endfunction
 
 " Section: Completion


### PR DESCRIPTION
Ref: https://github.com/tpope/vim-projectionist/issues/39#issuecomment-59689303