### PR TITLE
Fix syntax for BufNewFile autocmd

### DIFF
--- a/plugin/projectionist.vim
+++ b/plugin/projectionist.vim
@@ -95,6 +95,6 @@ augroup projectionist
   autocmd BufNewFile *
         \ if !empty(get(b:, 'projectionist')) |
         \   call projectionist#apply_template() |
-        \   setlocal nomodified
+        \   setlocal nomodified |
         \ endif
 augroup END


### PR DESCRIPTION
Hi,

This is a tiny syntax fix.
With this syntax error, `E518: Unknown option: endif` occurs (maybe when `!empty(get(b:, 'projectionist'))` is true).

Thank you for your awesome plugins :smile: 