### PR TITLE
Allow relative paths

### DIFF
--- a/autoload/projectionist.vim
+++ b/autoload/projectionist.vim
@@ -275,7 +275,7 @@ function! projectionist#query(key, ...) abort
 endfunction
 
 function! s:absolute(path, in) abort
-  if a:path =~# '^\%([[:alnum:].-]\+:\)\|^[\/]'
+  if a:path =~# '^\%([[:alnum:].-]\+:\)\|^\.\?[\/]'
     return a:path
   else
     return simplify(a:in . projectionist#slash() . a:path)


### PR DESCRIPTION
Closes #66.

Wasn't sure what the best string prefix would be, so I opted for using the transformation syntax.
If you think something else would be better (like `relative:`) the same code would work, just wouldn't need the `relative` transformation function.

As is, it has the downside that if you put it anywhere else in a string (`foo{relative}bar`) it will remain there verbatim.

What do you think?