### PR TITLE
Ignore null command completions

### DIFF
--- a/autoload/projectionist.vim
+++ b/autoload/projectionist.vim
@@ -443,7 +443,7 @@ function! projectionist#completion_filter(results, query, sep, ...) abort
   unlet! results
 
   let results = s:uniq(sort(copy(a:results)))
-  call filter(results,'v:val !~# "\\~$"')
+  call filter(results,'v:val !~# "\\~$" && !empty(v:val)')
   let filtered = filter(copy(results),'v:val[0:strlen(a:query)-1] ==# a:query')
   if !empty(filtered) | return filtered | endif
   if !empty(a:sep)


### PR DESCRIPTION
I ran across a weird bug while making a projections file for [rbenv](https://github.com/rbenv/rbenv). For some reason, typing `:Ecommand <TAB>` wasn't showing any completions.

After investigating, I noticed that the file `rbenv` was included in the glob used for building the completions but was then transform into a null string when substituting the format of the pattern.

This is the most elegant fix I could figure out after trying to change the substitution and format regexps and breaking other parts.

Projection file I used to find this bug : 
```json
{
  "libexec/rbenv-*": {
    "type": "command"
  }
}
```