### PR TITLE
Add lowercase filter

### DIFF
--- a/autoload/projectionist.vim
+++ b/autoload/projectionist.vim
@@ -135,6 +135,10 @@ function! g:projectionist_transformations.uppercase(input, o) abort
   return toupper(a:input)
 endfunction
 
+function! g:projectionist_transformations.lowercase(input, o) abort
+  return tolower(a:input)
+endfunction
+
 function! g:projectionist_transformations.camelcase(input, o) abort
   return substitute(a:input, '[_-]\(.\)', '\u\1', 'g')
 endfunction

--- a/doc/projectionist.txt
+++ b/doc/projectionist.txt
@@ -37,6 +37,7 @@ colons          / to ::
 hyphenate       _ to -
 blank           _ and - to space
 uppercase       uppercase
+lowercase       lowercase
 camelcase       foo_bar/baz_quux to fooBar/bazQuux
 snakecase       FooBar/bazQuux to foo_bar/baz_quux
 capitalize      capitalize first letter and each letter after a slash


### PR DESCRIPTION
In the webapps I'm mostly developing on (written in Perl), the "alternate" templates for controllers (like `Web_App::Foo::Bar`) are all lowercase (i.e. `templates/webapp/foo/bar.tt`), and there is no way to make that happen with projectionist currently.

This simple patch allows me to use projectionist on that project, with this config:

    {
      "lib/Web_App/*.pm": {
        "alternate": "templates/webapp/{lowercase}.tt"
      },
      "templates/webapp/*.tt": {
        "alternate": "lib/Web_App/{capitalize}.pm"
      }
    }

It's a fairly trivial one, granted.