### PR TITLE
Replace NERDTreeRoot with NERDTree.root (closes #89)

### DIFF
--- a/plugin/projectionist.vim
+++ b/plugin/projectionist.vim
@@ -86,7 +86,7 @@ augroup projectionist
         \   call projectionist#activate() |
         \ endif
   autocmd User NERDTreeInit,NERDTreeNewRoot
-        \ call ProjectionistDetect(b:NERDTreeRoot.path.str())
+        \ call ProjectionistDetect(b:NERDTree.root.path.str())
   autocmd VimEnter *
         \ if empty(expand('<afile>:p')) |
         \   call ProjectionistDetect(resolve(getcwd())) |


### PR DESCRIPTION
Ticket: Not compatible anymore with latest NERDTree #89
This was caused by latest NERDTree code clean up: Legacy buffer variable b:NERDTreeRoot was finally removed so it is time to make use of b:NERDTree.root instead