### PR TITLE
Search related files as default for :Efoo

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -73,8 +73,9 @@ Here are some examples for this very project:
 
 With these in place, you could use `:Eplugin projectionist` to edit
 `plugin/projectionist.vim` and `:Edoc projectionist` to edit
-`doc/projectionist.txt`.  For `README.markdown`, since there's no glob, it
-becomes the default destination for `:Edoc` if no argument is given.
+`doc/projectionist.txt`.  If no argument is given, it will edit an alternate
+file of that type (see below) or a projection without a glob.  So in this
+example `:Edoc` would default to editing `README.markdown`.
 
 The `E` stands for `edit`.  You also get `S`, `V`, and `T` variants that
 `split`, `vsplit`, and `tabedit`.
@@ -94,6 +95,9 @@ implementation and test:
       "src/main/java/*.java": {"alternate": "src/test/java/{}.java"},
       "src/test/java/*.java": {"alternate": "src/main/java/{}.java"}
     }
+
+In addition, the navigation commands (like `:Eplugin` above) will search
+alternates when no argument is given to edit a related file of that type.
 
 Bonus feature: `:A {filename}` edits a file relative to the root of the
 project.

--- a/doc/projectionist.txt
+++ b/doc/projectionist.txt
@@ -62,7 +62,8 @@ The full list of available properties in a projection is as follows:
 						*projectionist-alternate*
 "alternate" ~
         Determines the destination of the |projectionist-:A| command.  If this
-        is a list, the first readable file will be used.
+        is a list, the first readable file will be used.  Will also be used as
+        a default for |projectionist-related|.
 						*projectionist-console*
 "console" ~
         Command to run to start a REPL or other interactive shell.  Will be
@@ -99,6 +100,11 @@ The full list of available properties in a projection is as follows:
         this option is provided for a literal filename rather than a glob, it
         is used as the default destination of the navigation command when no
         argument is given.
+						*projectionist-related*
+"related" ~
+        Indicates one or more files to search when a navigation command is
+        called without an argument, to find a default destination.  Related
+        files are searched recursively.
 
                                                 *g:projectionist_heuristics*
 In addition to ".projections.json", projections can be defined globally


### PR DESCRIPTION
Adds a fallback for the navigation commands to search alternates for a file matching the corresponding type.  This allows, e.g., `:Emodel` from within a controller to edit the matching model file, provided alternates are set up.  Alternates are searched recursively, breadth-first.  To keep the search sane and bounded, only the first (most specific) set of alternates for a given file are considered, and recursion is limited to a maximum depth.  If no matching alternate is found this way, the current default of editing a glob-less projection of the given type, if any, still applies.

Fixes #80, #26, #22.

I've tested this with a typical React project structure as well as a more complex set of projections I whipped up for a Rails API project.  This particular app has a set of API-only controllers as well as an admin site under `/admin/`.  The projections look something like this:
```
      \   'Gemfile': {
      \     'app/models/*.rb': {
      \       'type': 'model',
      \       'alternate': [
      \         'db/schema.rb{lnum|nothing}',
      \         'spec/models/{}_spec.rb',
      \         'app/controllers/api/v1/{basename|plural}_controller.rb',
      \         'app/controllers/admin/{basename|plural}_controller.rb'
      \       ]
      \     },
      \     'app/controllers/*_controller.rb': {
      \       'type': 'controller',
      \       'alternate': [
      \         'app/views/{}/index.html.haml{lnum|nothing}',
      \         'spec/controllers/{}_controller_spec.rb',
      \         'app/models/{basename|singular}.rb'
      \       ]
      \     },
      \     'app/views/*.html.haml': {
      \       'type': 'view',
      \       'alternate': 'app/controllers/{dirname}_controller.rb'
      \     },
      \     'spec/*_spec.rb': {
      \       'type': 'spec',
      \       'alternate': 'app/{}.rb'
      \     },
      \     'db/schema.rb': {'type': 'schema'},
      \     'README.md': {'type': 'doc'}
      \   }
```
And the navigation defaulting seems to work pretty well.  From a controller, `:Emodel` and `:Espec` go to the right places, and vice-versa.  From a model spec, I was able to do `:Eview` and it traced it to the corresponding `index` view under `/admin/`.  `:Eschema` and `:Edoc` still went to `db/schema.rb` and the README, respectively.

I also initially flubbed the `spec` glob as `spec/*.rb`, which actually leads to a potentially infinite series of expansions.  The recursion limit when expanding alternates seems to handle this situation pretty well.

Let me know what you think, and thanks for the awesome plugin!