### PR TITLE
Allow to set compile and makeprg in separate attributes

### DIFF
--- a/autoload/projectionist.vim
+++ b/autoload/projectionist.vim
@@ -546,20 +546,24 @@ function! projectionist#activate() abort
           \ ':execute s:edit_command("<mods>", "'.excmd.'<bang>", <count>, <f-args>)'
   endfor
 
-  for [root, makeprg] in projectionist#query_exec('make')
+  for [root, compile] in projectionist#query_exec('compile')
     unlet! b:current_compiler
-    let compiler = fnamemodify(matchstr(makeprg, '\S\+'), ':t:r')
+    let compiler = fnamemodify(matchstr(compile, '\S\+'), ':t:r')
     setlocal errorformat=%+I%.%#,
     if exists(':Dispatch')
-      silent! let compiler = dispatch#compiler_for_program(makeprg)
+      silent! let compiler = dispatch#compiler_for_program(compile)
     endif
     if !empty(findfile('compiler/'.compiler.'.vim', escape(&rtp, ' ')))
       execute 'compiler' compiler
     elseif compiler ==# 'make'
       setlocal errorformat<
     endif
-    let &l:makeprg = makeprg
     let &l:errorformat .= ',%\&chdir '.escape(root, ',')
+    break
+  endfor
+
+  for [root, makeprg] in projectionist#query_exec('makeprg')
+    let &l:makeprg = makeprg
     break
   endfor
 


### PR DESCRIPTION
I'm working on a Rust project that uses `cargo` as the compiler but the make program is a built in thing written in Python `./x.py`.

So here is how I want my project `.projections.json` to look like ...

```
{
	"*": {
		"compile": "cargo",
		"makeprg": "./x.py"
	}
}
```

With this PR this works.

With the actual projectionist version I'm not sure how to accomplish that because the only thing I can set is `"make"` and if I do so it sets `"makeprg"` correctly but does not set the compiler in the right way.