### PR TITLE
Workaround for terminal popup cursor jump bug

### DIFF
--- a/plugin/projectionist.vim
+++ b/plugin/projectionist.vim
@@ -143,7 +143,7 @@ augroup projectionist
         \   call ProjectionistDetect(expand('%:p')) |
         \ endif
   autocmd BufFilePost *
-        \ if filereadable(expand('<afile>:p')) |
+        \ if expand('<afile>') !~# '^!' |
         \   call ProjectionistDetect(expand('<afile>:p')) |
         \ endif
   autocmd BufNewFile,BufReadPost *

--- a/plugin/projectionist.vim
+++ b/plugin/projectionist.vim
@@ -142,7 +142,10 @@ augroup projectionist
         \     &buftype !~# 'nofile\|quickfix' |
         \   call ProjectionistDetect(expand('%:p')) |
         \ endif
-  autocmd BufFilePost * call ProjectionistDetect(expand('<afile>:p'))
+  autocmd BufFilePost *
+        \ if filereadable(expand('<afile>:p')) |
+        \   call ProjectionistDetect(expand('<afile>:p')) |
+        \ endif
   autocmd BufNewFile,BufReadPost *
         \ if empty(&filetype) |
         \   call ProjectionistDetect(expand('<afile>:p')) |


### PR DESCRIPTION
Vim patch 8.2.0413 enables BufFilePre and BufFilePost autocmds for
terminal buffers. This causes the cursor to jump to the start of the
current buffer when projectionist is enabled and a terminal popup window
is created, for example by either the FZF.vim or vim-floaterm plugins.

Terminal popup windows are created by starting a hidden terminal buffer
and then creating a popup to show that terminal buffer. Projectionist's
BufFilePost autocmd is now triggered for these hidden terminal buffers,
and somewhere along the line this causes the cursor to jump to the top.

I'm not sure exactly what causes this cursor jump, but one workaround is
to add a condition to the autocmd to only call ProjectionistDetect if
the autocmd file name refers to a file that actually exists/isreadable.

This seems reasonable to me, so this commit just adds that condition.

More information:
https://github.com/vim/vim/issues/5820
https://github.com/junegunn/fzf.vim/issues/1164
https://github.com/tpope/vim-projectionist/issues/155