### PR TITLE
fix(typo): using `.` instead of `:` in a ternary

### DIFF
--- a/plugin/projectionist.vim
+++ b/plugin/projectionist.vim
@@ -78,7 +78,7 @@ function! ProjectionistDetect(path) abort
   elseif tr(a:path, s:slash, '/') =~# '^\a\+:\|^/'
     let file = a:path
   else
-    let file = simplify(getcwd() . (exists('+shellslash') && !&shellslash ? '\' . '/') . a:path)
+    let file = simplify(getcwd() . (exists('+shellslash') && !&shellslash ? '\' : '/') . a:path)
   endif
 
   let ns = matchstr(file, '^\a\a\+\ze:')


### PR DESCRIPTION
Hi,

After updating the plugin today:
```
Error detected while processing function ProjectionistDetect:
line    8:
E109: Missing ':' after '?'
E116: Invalid arguments for function simplify
Press ENTER or type command to continue
```

The line in cause: https://github.com/tpope/vim-projectionist/blob/eb86c33f05657e3bb3a686b50324367cfe539fde/plugin/projectionist.vim#L81

Probably just a typo: the `:` from the ternary is missing, a `.` was used instead.