### PR TITLE
Make Console accept <mods>

### DIFF
--- a/autoload/projectionist.vim
+++ b/autoload/projectionist.vim
@@ -608,7 +608,7 @@ function! projectionist#activate() abort
     execute 'command! -bar -bang -buffer -nargs=* Console ' .
           \ (exists(':Start') < 2 ?
           \ 'ProjectDo ' . (offset == 1 ? '' : offset.' ') . '!' . command :
-          \ 'Start<bang> ' . b:start) . ' <args>'
+          \ '<mods> Start<bang> ' . b:start) . ' <args>'
     break
   endfor
 


### PR DESCRIPTION
Hi @tpope, I have realized the `Console` command, and found it have a little difference behavior with `Start`. It does not accept <mods>, this pr fix that