### PR TITLE
feat: rotating lists of alternate files

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -117,6 +117,8 @@ You can define lists of files to rotate, using a more generic pattern:
 
 Then you can rotate the list with `:Anext` and `:Aprev`.
 
+The "rotate" key is used as default for "alternate", if that isn't defined. 
+
 ### Buffer configuration
 
 Check out these examples for a minimal Ruby project:

--- a/README.markdown
+++ b/README.markdown
@@ -104,6 +104,19 @@ project.
 
 [a.vim]: http://www.vim.org/scripts/script.php?script_id=31
 
+### Rotating lists of alternate files
+
+You can define lists of files to rotate, using a more generic pattern:
+
+    {
+        "src/*": {
+            "rotate": [ "src/{}.c", "src/{}.h", "src/proto/{}.pro" ],
+            "type": "source"
+        }
+    }
+
+Then you can rotate the list with `:Anext` and `:Aprev`.
+
 ### Buffer configuration
 
 Check out these examples for a minimal Ruby project:

--- a/autoload/projectionist.vim
+++ b/autoload/projectionist.vim
@@ -407,7 +407,11 @@ function! projectionist#query_raw(key, ...) abort
     endif
     for pattern in reverse(sort(filter(keys(projections), 'v:val =~# s:valid_key && v:val =~# "\\*"'), function('projectionist#lencmp')))
       let match = s:match(name, pattern)
-      if (!empty(match) || pattern ==# '*') && has_key(projections[pattern], a:key)
+      " if 'rotate' is defined and 'alternate' isn't, use it as default for the latter
+      let key = a:key == 'rotate'
+                  \ || (a:key == 'alternate' && !has_key(projections[pattern], 'alternate'))
+                  \ ? 'rotate' : a:key
+      if (!empty(match) || pattern ==# '*') && has_key(projections[pattern], key)
         let expansions = extend({'match': match}, attrs)
         " if key is 'rotate', and value is a list with multiple patterns,
         " match current file among candidates; if it matches, set the index in
@@ -415,7 +419,7 @@ function! projectionist#query_raw(key, ...) abort
         " Note: b:projectionist_file must correspond to current file. It can be
         " temporarily different during the execution of some navigation
         " commands.
-        if a:key == 'rotate' && !empty(match) && file == expand('%:p')
+        if key == 'rotate' && !empty(match) && file == expand('%:p')
           let alts = projections[pattern]['rotate']
           if type(alts) != type([]) || len(alts) == 1
             continue
@@ -430,7 +434,7 @@ function! projectionist#query_raw(key, ...) abort
             endif
           endfor
         endif
-        call add(candidates, [projections[pattern][a:key], expansions])
+        call add(candidates, [projections[pattern][key], expansions])
       endif
     endfor
   endfor

--- a/doc/projectionist.txt
+++ b/doc/projectionist.txt
@@ -69,7 +69,8 @@ The full list of available properties in a projection is as follows:
         It can be used as a rotating list of alternate files, then you can use
         |:Anext| and |:Aprev| to navigate the list. Note that in this case the
         `*` is replaced with the name of the current file, without the
-        extension.  Eg.: >
+        extension.  It is also used as default for |projectionist-alternate|,
+        if that isn't defined. Eg.: >
           {
             "src/*": {
               "rotate": [

--- a/doc/projectionist.txt
+++ b/doc/projectionist.txt
@@ -61,9 +61,22 @@ The full list of available properties in a projection is as follows:
 
 						*projectionist-alternate*
 "alternate" ~
-        Determines the destination of the |projectionist-:A| command.  If this
-        is a list, the first readable file will be used.  Will also be used as
-        a default for |projectionist-related|.
+        Determines the destination of the |projectionist-:A| command. Will
+        also be used as a default for |projectionist-related|.
+        If this is a list, it can be used as a rotating list of alternate
+        files, then you can use |:Anext| and |:Aprev| to navigate the list.
+        Eg.: >
+          {
+            "src/*": {
+              "alternate": [
+                "src/{}.c",
+                "src/{}.h",
+                "src/proto/{}.pro"
+              ],
+              "type": "source"
+            }
+          }
+<
 						*projectionist-console*
 "console" ~
         Command to run to start a REPL or other interactive shell.  Will be
@@ -149,6 +162,10 @@ In addition to any navigation commands provided by your projections (see
                         defined by the "alternate" key.
 
 :A {file}               Edit {file} relative to the innermost root.
+                                                *projectionist-:Anext*
+:Anext                  Next entry in the "alternate" rotating list.
+                                                *projectionist-:Aprev*
+:Aprev                  Previous entry in the "alternate" rotating list.
                                                 *projectionist-:AS*
 :AS [file]              Like :A, but open in a split.
                                                 *projectionist-:AV*

--- a/doc/projectionist.txt
+++ b/doc/projectionist.txt
@@ -67,7 +67,9 @@ The full list of available properties in a projection is as follows:
 						*projectionist-rotate*
 "rotate" ~
         It can be used as a rotating list of alternate files, then you can use
-        |:Anext| and |:Aprev| to navigate the list.  Eg.: >
+        |:Anext| and |:Aprev| to navigate the list. Note that in this case the
+        `*` is replaced with the name of the current file, without the
+        extension.  Eg.: >
           {
             "src/*": {
               "rotate": [

--- a/doc/projectionist.txt
+++ b/doc/projectionist.txt
@@ -61,14 +61,16 @@ The full list of available properties in a projection is as follows:
 
 						*projectionist-alternate*
 "alternate" ~
-        Determines the destination of the |projectionist-:A| command. Will
-        also be used as a default for |projectionist-related|.
-        If this is a list, it can be used as a rotating list of alternate
-        files, then you can use |:Anext| and |:Aprev| to navigate the list.
-        Eg.: >
+        Determines the destination of the |projectionist-:A| command.  If this
+        is a list, the first readable file will be used.  Will also be used as
+        a default for |projectionist-related|.
+						*projectionist-rotate*
+"rotate" ~
+        It can be used as a rotating list of alternate files, then you can use
+        |:Anext| and |:Aprev| to navigate the list.  Eg.: >
           {
             "src/*": {
-              "alternate": [
+              "rotate": [
                 "src/{}.c",
                 "src/{}.h",
                 "src/proto/{}.pro"
@@ -163,9 +165,9 @@ In addition to any navigation commands provided by your projections (see
 
 :A {file}               Edit {file} relative to the innermost root.
                                                 *projectionist-:Anext*
-:Anext                  Next entry in the "alternate" rotating list.
+:Anext                  Edit the next entry in the "rotate" list.
                                                 *projectionist-:Aprev*
-:Aprev                  Previous entry in the "alternate" rotating list.
+:Aprev                  Edit the previous entry in the "rotate" list.
                                                 *projectionist-:AS*
 :AS [file]              Like :A, but open in a split.
                                                 *projectionist-:AV*


### PR DESCRIPTION

When you want more alternate files for a certain type of files, defining them becomes cumbersome.

For example if you want to alternate among `src/x.c`, `src/x.h` and `src/proto/x.pro`, you are forced to do something like:
```json
{
	"src/*.c": {
		"alternate": [
			"src/{}.h",
			"src/proto/{}.pro"
		],
		"type": "source"
	},
	"src/*.h": {
		"alternate": [
			"src/proto/{}.pro",
			"src/{}.c"
		],
		"type": "source"
	},
	"src/proto/*.pro": {
		"alternate": [
			"src/{}.c",
			"src/{}.h"
		],
		"type": "source"
	},
}
```
Having to include in the list also alternatives for files that maybe don't exist, in the correct order. This become even worse if there are more than 3 candidates. With this PR rotating lists can be defined with:

```json
{
	"src/*": {
		"rotate": [
			"src/{}.c",
			"src/{}.h",
			"src/proto/{}.pro"
		],
		"type": "source"
	}
}
```
Then you can use `:Anext` and `:Aprev` in mappings like `]r` and `[r`.

The feature is inspired by [kana/vim-altr](https://github.com/kana/vim-altr), where this is possible.

The last commit allows to use the `rotate` key as default for `alternate`, it's not strictly necessary and could have side effects, but it won't break anything I guess.
