### PR TITLE
Ignore VimEnter autocommand when starting with a session

### DIFF
--- a/plugin/projectionist.vim
+++ b/plugin/projectionist.vim
@@ -161,7 +161,7 @@ augroup projectionist
         \   call s:Detect(b:NERDTree.root.path.str()) |
         \ endif
   autocmd VimEnter *
-        \ if get(g:, 'projectionist_vim_enter', 1) && argc() == 0 && v:this_session == '' |
+        \ if get(g:, 'projectionist_vim_enter', 1) && argc() == 0 && empty(v:this_session) |
         \   call s:Detect(getcwd()) |
         \ endif
   autocmd BufWritePost .projections.json call s:Detect(expand('<afile>'))

--- a/plugin/projectionist.vim
+++ b/plugin/projectionist.vim
@@ -161,7 +161,7 @@ augroup projectionist
         \   call s:Detect(b:NERDTree.root.path.str()) |
         \ endif
   autocmd VimEnter *
-        \ if get(g:, 'projectionist_vim_enter', 1) && argc() == 0 |
+        \ if get(g:, 'projectionist_vim_enter', 1) && argc() == 0 && v:this_session == '' |
         \   call s:Detect(getcwd()) |
         \ endif
   autocmd BufWritePost .projections.json call s:Detect(expand('<afile>'))


### PR DESCRIPTION
This is my proposed fix for https://github.com/tpope/vim-projectionist/issues/185.

The solution here is to simply ignore the `VimEnter` autocommand when started with a session file, since starting with an existing session is functionally equivalent to having started with a specific file to edit (when `argc() > 0`).

A possible alternative solution would be to listen for the `SessionLoadPost` autocommand and do something like set `g:projectionist_vim_enter = 0`, but this solution is shorter and more straightforward.