### PR TITLE
Support directories with '@'

### DIFF
--- a/autoload/projectionist.vim
+++ b/autoload/projectionist.vim
@@ -804,7 +804,7 @@ endfunction
 " Section: :A
 
 function! s:jumpopt(file) abort
-  let pattern = '!$\|:\d\+:\d\+$\|[:@#]\d\+$\|[@#].*$'
+  let pattern = '!$\|:\d\+:\d\+$\|[:@#]\d\+$'
   let file = substitute(a:file, pattern, '', '')
   let jump = matchstr(a:file, pattern)
   if jump =~# '^:\d\+:\d\+$'


### PR DESCRIPTION
My new company laptop enforces that the username is our company email - so my home directory ended up being something like `/Users/Drowze@example.com` - that broke the `:A`  command for me.

Reproducing the issue:
```vim
" .vimrc
let g:projectionist_heuristics = {
\ 'lib/*': {
\   'lib/*.rb': { 'alternate': 'spec/{}_spec.rb' },
\   'spec/*_spec.rb': { 'alternate': 'lib/{}.rb' }
\ }}
```

```bash
$ mkdir -p test2@abc/{lib,spec}
$ touch test2@abc/lib/foo.rb test2@abc/spec/foo_spec.rb
$ vim test@abc/lib/foo.rb
# try to use :A inside vim
```

![Screenshot 2024-03-15 at 15 50 56](https://github.com/tpope/vim-projectionist/assets/9031589/d76dbceb-17fc-48cb-bc4e-00fd9abe928e)


This PR is an attempt to fix this issue with the `:A` command - at least for my usage.

NOTE:
- I'm not sure about other features from vim-projectionist - whether they work fine or not with directories containing `@`.
- I'm also not sure what the removed regex was useful for, so I'm not sure if this breaks some other edge case.
