### PR TITLE
feat: show shorter candidate names in "Create alternate" list

### DIFF
--- a/autoload/projectionist.vim
+++ b/autoload/projectionist.vim
@@ -851,7 +851,8 @@ function! s:edit_command(mods, edit, count, ...) abort
       let i = 0
       for [alt, _] in alternates
         let i += 1
-        call add(choices, i.' '.alt)
+        let relative = fnamemodify(alt, ":~:.")
+        call add(choices, i.' '.relative)
       endfor
       let i = inputlist(choices)
       if i > 0


### PR DESCRIPTION
Before this change, the "Create alternate file?" prompt would show absolute paths. This can be quite verbose and hard to read:

    Create alternate file?
    1 /Users/greg.hurrell/code/wincent/aspects/nvim/files/.config/nvim/pack/bundle/opt/demo/src/example.test.ts
    2 /Users/greg.hurrell/code/wincent/aspects/nvim/files/.config/nvim/pack/bundle/opt/demo/src/example.unit.ts
    3 /Users/greg.hurrell/code/wincent/aspects/nvim/files/.config/nvim/pack/bundle/opt/demo/src/__tests__/example.test.ts
    4 /Users/greg.hurrell/code/wincent/aspects/nvim/files/.config/nvim/pack/bundle/opt/demo/src/__tests__/example-test.ts
    5 /Users/greg.hurrell/code/wincent/aspects/nvim/files/.config/nvim/pack/bundle/opt/demo/src/__tests__/example-mocha.ts
    6 /Users/greg.hurrell/code/wincent/aspects/nvim/files/.config/nvim/pack/bundle/opt/demo/src/example.test.tsx
    7 /Users/greg.hurrell/code/wincent/aspects/nvim/files/.config/nvim/pack/bundle/opt/demo/src/example.unit.tsx
    8 /Users/greg.hurrell/code/wincent/aspects/nvim/files/.config/nvim/pack/bundle/opt/demo/src/__tests__/example.test.tsx
    9 /Users/greg.hurrell/code/wincent/aspects/nvim/files/.config/nvim/pack/bundle/opt/demo/src/__tests__/example-test.tsx
    10 /Users/greg.hurrell/code/wincent/aspects/nvim/files/.config/nvim/pack/bundle/opt/demo/src/__tests__/example-mocha.tsx
    Type number and <Enter> or click with the mouse (q or empty cancels):

With this proposed change, we instead show candidate names as relative to the current working directory (ie. modifier ":.") if they are below the current directory, and we abbreviate the `$HOME` directory to "~" (ie. modifier ":~") if they are inside the home directory.

    Create alternate file?
    1 src/example.test.ts
    2 src/example.unit.ts
    3 src/__tests__/example.test.ts
    4 src/__tests__/example-test.ts
    5 src/__tests__/example-mocha.ts
    6 src/example.test.tsx
    7 src/example.unit.tsx
    8 src/__tests__/example.test.tsx
    9 src/__tests__/example-test.tsx
    10 src/__tests__/example-mocha.tsx
    Type number and <Enter> or click with the mouse (q or empty cancels):

Note that this commit only changes what is displayed in the list; the actual `alt` variable remains as before (an absolute path) and the rest of the code continues as it was. Later on, funnily enough, the existing code abbreviates the name in the same way (with another call to `fnamemodify()`) on line 869, but I wanted to keep this commit as minimal as possible to reduce risk, so I made no attempt to factor out the repeated calls. I can do that, though, if reviewers want it that way.