### PR TITLE
Fix pattern match for absolute path projections

### DIFF
--- a/autoload/projectionist.vim
+++ b/autoload/projectionist.vim
@@ -398,6 +398,10 @@ function! projectionist#query_raw(key, ...) abort
   let file = a:0 ? a:1 : get(b:, 'projectionist_file', expand('%:p'))
   for [path, projections] in s:all()
     let attrs = {'project': path, 'file': file}
+    " Remove duplicated slashes in path, e.g. ///home/folder
+    let path = substitute(path, '/\{2,}', '/', 'g')
+    let file = substitute(file, '/\{2,}', '/', 'g')
+
     if path == '/'
       let name = file
     else

--- a/autoload/projectionist.vim
+++ b/autoload/projectionist.vim
@@ -398,7 +398,11 @@ function! projectionist#query_raw(key, ...) abort
   let file = a:0 ? a:1 : get(b:, 'projectionist_file', expand('%:p'))
   for [path, projections] in s:all()
     let attrs = {'project': path, 'file': file}
-    let name = file[strlen(path)+1:-1]
+    if path == '/'
+      let name = file
+    else
+      let name = file[strlen(path)+1:-1]
+    endif
     if strpart(file, 0, len(path)) !=# path
       let name = ''
     endif


### PR DESCRIPTION
Absolute path projections are useful when you want to access specific projections in your editor regardless of what file you're editing, e.g. `Eplugin mappings` to edit `/home/username/.vim/plugin/mappings.vim`.

I had absolute path projections that weren't working properly with `projectionist#query` because it would incorrectly infer the name of the file to match against the pattern.

The error occurs because the original logic assumes the pattern must be done always against a relative directory. Traditionally, it happens like so:

```
path: /home/username/project
file: /home/username/project/main.vim
name: main.vim
```

With this patch, variables are such for absolute projections:

```
path: /
file: /home/username/.vim/plugin/mappings.vim
name: /home/username/.vim/plugin/mappings.vim
```

Before this patch, name was being computed as:

```
name: ome/username/.vim/plugin/mappings.vim
```