### PR TITLE
Add support for backrefs in file names

### DIFF
--- a/autoload/projectionist.vim
+++ b/autoload/projectionist.vim
@@ -67,7 +67,6 @@ endfunction
 function! projectionist#json_parse(string) abort
   let string = type(a:string) == type([]) ? join(a:string, ' ') : a:string
   if exists('*json_decode')
-    try
       return json_decode(string)
     catch
     endtry


### PR DESCRIPTION
At my work I'm working with a lot of custom EDA tools that have redundant filename patterns. So, backrefs in the file names would useful, at least for me! Please let me know what you think. I did a few manual tests to check for navigating and completion working on both Windows and Linux.

For paths with redundancy, capture the repeating part of the path. Any * or ** in the pattern creates a capture group, which can be repeated with {1}, {2}, {3}, etc.  Also, adds support for multiple single * groups, and for * before **. Can support up to one **, and it groups all extra matches into it like "x/y/z".

Example .projections.json:
```
{
    "src/config/*/{1}.cfg": {
        "type": "config",
        "template": "# Configuration for {}\n# Add your config settings here\n"
    },
    "*/{1}/**/*/{3}.abc": {
        "type": "abc",
        "template": "# Abc for {}"
    },
    "**/*/{2}/*/{3}.bcd": {
        "type": "bcd",
        "template": "# Bcd for {}"
    }
}
```

Examples:
`:Econfig tmp` -> src/config/tmp/tmp.cfg
`:Eabc a/c` -> a/a/c/c.abc
`:Eabc a/x/y/z/c` -> a/a/x/y/z/c/c.abc